### PR TITLE
move interfaceguid convertor from golang to psm1

### DIFF
--- a/src/SwitchValidation.psm1
+++ b/src/SwitchValidation.psm1
@@ -83,12 +83,21 @@ function Invoke-SwitchValidation {
       if ($intf.ifIndex -eq $ifIndex ) {
         $inftAlias = $intf.InterfaceAlias -replace " ",""
         $inftGUID = $intf.InterfaceGuid
-        write-host "interface $inftAlias is selected"
+        # Windows NIC name is different from Linux, which need to be converted before use in gopacket lib.
+        # PS C:\Users\liunick\Downloads\Test> Get-NetAdapter | Select-Object InterfaceAlias,InterfaceIndex,InterfaceGuid,DeviceName
+        # InterfaceAlias InterfaceIndex InterfaceGuid                          DeviceName
+        # -------------- -------------- -------------                          ----------
+        # NIC1                      18 {A91A8E1F-C8B3-4D96-A403-78B9E758EA38} \Device\{A91A8E1F-C8B3-4D96-A403-78B9E758EA38}
+        #####
+        # Powershell interfaceGUID: "{A91A8E1F-C8B3-4D96-A403-78B9E758EA38}"
+        # Gopacket interface format: "\Device\NPF_{A91A8E1F-C8B3-4D96-A403-78B9E758EA38}"
+        $interfaceGUID="Device\NPF_$($inftGUID)"
+        write-host "## Interface Name $inftAlias is selected, [Debug InterfaceGUID: $interfaceGUID] ##"
       } 
     }
     
-    if ($inftGUID -ne "" -and $inftAlias -ne "") {
-      $arguments += "-interfaceAlias `"$inftAlias`" -interfaceGUID `"$($inftGUID)`""
+    if ($interfaceGUID -ne "" -and $inftAlias -ne "") {
+      $arguments += "-interfaceAlias `"$inftAlias`" -interfaceGUID `"$($interfaceGUID)`""
       if ($nativeVlanID -ne 0) {
         $arguments += " -nativeVlanID `"$nativeVlanID`""
       }

--- a/src/main.go
+++ b/src/main.go
@@ -64,7 +64,7 @@ func main() {
 	// pcapFilePath := "./test/success_lldp.pcap"
 	fileIsExist(pcapFilePath)
 	OutputObj.resultAnalysis(pcapFilePath, inputObj)
-	log.Println(OutputObj)
+	// log.Println(OutputObj)
 	pdfFilePath := fmt.Sprintf("./Report_%s.pdf", inputObj.InterfaceAlias)
 	OutputObj.outputPDFbyFile(pdfFilePath)
 }
@@ -98,12 +98,6 @@ func (i *InputType) loadInputVariable() {
 		}
 		i.AllVlanIDs = append(i.AllVlanIDs, vlanid)
 	}
-
-	// Powershell interfaceGUID: "{0217D729-CED0-4D06-9C66-592E032A37A8}"
-	// Gopacket interface format: "\Device\NPF_{0217D729-CED0-4D06-9C66-592E032A37A8}"
-	goInterface := fmt.Sprintf(`\Device\NPF_%s`, i.InterfaceGUID)
-	i.InterfaceGUID = goInterface
-	// log.Printf("InputObj:%#v\n", i)
 }
 
 func RemoveSliceDup(intSlice []int) []int {


### PR DESCRIPTION
Windows: move interfaceguid convertor from golang to psm1, which easier for windows OS to debug interface name.