### PR TITLE
Users/camilose/cg fix

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module SwitchValidationTool
 
-go 1.24
+go 1.25
 
 require (
 	github.com/go-pdf/fpdf v0.9.0


### PR DESCRIPTION
# Problem
Component governance requires us to upgrade package `golang.org/x/image` to version `v0.38.0`. The package has been upgraded but the build pipeline has failed because `v0.38.0` now requires Go version >=1.25.0

<img width="301" height="31" alt="image" src="https://github.com/user-attachments/assets/b4e17014-76b3-4742-bbba-7d13c4d64241" />

# Solution

Upgrading Go version from 1.24 -> 1.25